### PR TITLE
fix: update LocalStack license requirement and standardize CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,18 @@ $(VENV_ACTIVATE):
 venv: $(VENV_ACTIVATE)    ## Create a new (empty) virtual environment
 
 start:                    ## Start the localstack container in the detached mode
-	$(LOCAL_ENV) docker compose up --build --detach --wait
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	$(LOCAL_ENV) LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) docker compose up --build --detach --wait
+
+stop:                     ## Stop the localstack container
+	docker compose down
+
+ready:                    ## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:                     ## Save the logs in a separate file
+	@localstack logs > logs.txt
 
 install: venv             ## Install the dependencies                 
 	$(VENV_RUN); $(PIP_CMD) install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -8,20 +8,21 @@ This scenario demonstrates how to use Database Migration Service (DMS) to create
 
 ## Pre-requisites
 
--   [LocalStack Auth Token](https://docs.localstack.cloud/getting-started/auth-token/)
+-   A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+-   [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 -   [Python 3.10](https://www.python.org/downloads/) & `pip`
 -   [Docker Compose](https://docs.docker.com/compose/install/)
 -   [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/)  with the  [`cdklocal`](https://github.com/localstack/aws-cdk-local) wrapper.
 
-  
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN`  pre-configured:
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```bash
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
-docker-compose up
+make start
+make ready
 ```
 
-The Docker Compose file will start LocalStack Pro container and a MariaDB container. The MariaDB container will be used to showcase how to reach a database external to LocalStack.
+The Docker Compose file will start LocalStack container and a MariaDB container. The MariaDB container will be used to showcase how to reach a database external to LocalStack.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary

- Add auth guard and stop/ready/logs targets to Makefile
- Add license bullet and update start section in README
- Upgrade checkout@v3->v4, setup-node@v3->v4 in CI workflow
